### PR TITLE
core: add a sequencer module in the core library

### DIFF
--- a/core/postgres.mli
+++ b/core/postgres.mli
@@ -247,7 +247,7 @@ module Connection : sig
     :  t
     -> [> `Close of int | `Write of Faraday.bigstring Faraday.iovec list | `Yield ]
 
-  val next_read_operation : t -> [> `Close | `Read ]
+  val next_read_operation : t -> [> `Close | `Read | `Yield ]
   val read : t -> Angstrom.bigstring -> off:int -> len:int -> int
   val read_eof : t -> Angstrom.bigstring -> off:int -> len:int -> int
   val yield_reader : t -> (unit -> unit) -> unit

--- a/test_driver/test_driver_lwt.ml
+++ b/test_driver/test_driver_lwt.ml
@@ -46,6 +46,8 @@ let () =
      let name = "my_unique_query" in
      let* () = prepare_query name conn in
      let* () = run name conn [ 9l; 2l; 3l ]
-     and* () = run name conn [ 2l; 4l; 10l ] in
+     and* () = run name conn [ 2l; 4l; 10l ]
+     and* () = run name conn [ 1l; 7l; 5l ]
+     and* () = run name conn [ 78l; 11l; 6l ] in
      let+ () = Postgres_lwt.close conn in
      Logs.info (fun m -> m "Finished"))


### PR DESCRIPTION
This should allow for running Postgres operations in sequence, even if the user tries to call functions in parallel. Instead of trying to run things as and when they come, the core library will enqueue each item onto a queue so different operations don't step on each other. Before this change we were enforcing the sequencing at the io library layer via `Lwt_mutex`, `Async.Throttle` etc. Having this be part of the core would enforce this behavior without the io layers needing to worry about it.

Related to #5 