### PR TITLE
Handle potential exceptions in data_row handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-Work-in-progress IO agnostic postgres client
+Work-in-progress IO agnostic postgres client. Supports connections over tcp (mirage + lwt.unix) and unix_domain_sockets (lwt.unix only).
+Tcp connections also support encrypting postgres sessions over an ssl connection.
 ```ocaml
 open Lwt.Syntax
 
@@ -51,12 +52,9 @@ let run name conn ids =
 
 Incomplete TODO list:
 
-* Tests (Lots of tests)
-* better error handling
 * add functions that'll clean up by closing connections after finishing a task
 * support binary format for parameters
 * Support additional auth methods (only MD5 and cleartext is implemented at the moment)
-* ~~Support SSL/TLS connections~~ (we only support ocaml-tls at the moment)
 * Add parser/serializer for all postgres backend/frontend messages
 * add wrapper to handle parameters in an easier manner
 * documentation


### PR DESCRIPTION
Data row handlers could potentially raise exceptions. When that happens
we shouldn't trash the connection. We can instead read and drop all
subsequent data rows, and then report the exception when we finish
reading the entire postgres response (we wait for ReadyForQuery message)