### PR TITLE
use async/lwt specific sequencers

### DIFF
--- a/async/pg_async.mli
+++ b/async/pg_async.mli
@@ -43,13 +43,15 @@ val create_ssl_options
   -> unit
   -> ssl_options
 
-val connect : Connection.User_info.t -> Destination.t -> Connection.t Deferred.Or_error.t
+type t
+
+val connect : Connection.User_info.t -> Destination.t -> t Deferred.Or_error.t
 
 val prepare
   :  statement:string
   -> ?name:string
   -> ?oids:Types.Oid.t array
-  -> Connection.t
+  -> t
   -> unit Deferred.Or_error.t
 
 val execute
@@ -57,7 +59,7 @@ val execute
   -> ?statement:string
   -> ?parameters:Frontend.Bind.parameter array
   -> (string option list -> unit)
-  -> Connection.t
+  -> t
   -> unit Deferred.Or_error.t
 
-val close : Postgres.Connection.t -> unit Deferred.Or_error.t
+val close : t -> unit Deferred.Or_error.t

--- a/lwt/postgres_lwt.mli
+++ b/lwt/postgres_lwt.mli
@@ -33,16 +33,18 @@ type error =
   | `Msg of string
   ]
 
+type t
+
 val connect
   :  (Connection.t -> unit)
   -> Connection.User_info.t
-  -> (Connection.t, [> error ]) Lwt_result.t
+  -> (t, [> error ]) Lwt_result.t
 
 val prepare
   :  statement:string
   -> ?name:string
   -> ?oids:Types.Oid.t array
-  -> Connection.t
+  -> t
   -> (unit, [> error ]) Lwt_result.t
 
 val execute
@@ -50,7 +52,7 @@ val execute
   -> ?statement:string
   -> ?parameters:Frontend.Bind.parameter array
   -> (string option list -> unit)
-  -> Connection.t
+  -> t
   -> (unit, [> error ]) Lwt_result.t
 
-val close : Connection.t -> (unit, [> error ]) Lwt_result.t
+val close : t -> (unit, [> error ]) Lwt_result.t

--- a/lwt_unix/postgres_lwt_unix.mli
+++ b/lwt_unix/postgres_lwt_unix.mli
@@ -8,4 +8,4 @@ val connect
   :  ?tls_config:Tls.Config.client
   -> Postgres.Connection.User_info.t
   -> destination
-  -> (Postgres.Connection.t, [> Postgres_lwt.error ]) Lwt_result.t
+  -> (Postgres_lwt.t, [> Postgres_lwt.error ]) Lwt_result.t

--- a/mirage/postgres_mirage.mli
+++ b/mirage/postgres_mirage.mli
@@ -42,5 +42,5 @@ module Make
     -> ?tls_config:Tls.Config.client
     -> Postgres.Connection.User_info.t
     -> destination
-    -> (Postgres.Connection.t, [> Postgres_lwt.error ]) Lwt_result.t
+    -> (Postgres_lwt.t, [> Postgres_lwt.error ]) Lwt_result.t
 end


### PR DESCRIPTION
The io monad independant sequencer was a little brittle and the
implementation was starting to get a little difficult to follow.
Keep the core simple for now and rely on lwt/async constructs to ensure
that only one job runs at any given time.